### PR TITLE
Add July 30 show at Wandering Goat

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -45,7 +45,7 @@
       "date": "2025/07/30",
       "venue": "Wandering Goat",
       "location": "Eugene, OR",
-      "bands": ["Poison Tribe", "Vacancy Floor", "Distraction of Beauty", "Cryptic Divination"],
+      "bands": ["Cryptic Divination", "Distraction of Beauty", "Vacancy Floor", "Poison Tribe"],
       "info": "$10, all ages"
     }
   ]

--- a/shows.html
+++ b/shows.html
@@ -40,6 +40,13 @@
       "venue": "John Henry's",
       "location": "Eugene, OR",
       "bands": ["The Unbridled", "Fire Priestess", "Cryptic Divination"]
+    },
+    {
+      "date": "2025/07/30",
+      "venue": "Wandering Goat",
+      "location": "Eugene, OR",
+      "bands": ["Poison Tribe", "Vacancy Floor", "Distraction of Beauty", "Cryptic Divination"],
+      "info": "$10, all ages"
     }
   ]
   </script>
@@ -179,6 +186,9 @@
             <strong>Links:</strong>
             <ol>${show.links.map(b => `<li><a href="${b}" target="_blank">${b}</a></li>`).join("")}</ol>
           `;
+      }
+      if (show.info) {
+          details.innerHTML += `<p>${show.info}</p>`;
       }
 
       li.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- add new show entry for July 30, 2025 at Wandering Goat
- support optional `info` field for each show and render beneath links

## Testing
- `tidy -qe shows.html` *(fails: `tidy` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686818e781ac832eb062ef632418225e