### PR TITLE
Embed Instagram posts below follow button

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -110,6 +110,20 @@ footer a {
         color: #ff0000;
 }
 
+.instagram-tiles {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 10px;
+        margin-top: 20px;
+}
+
+.instagram-tiles iframe {
+        border: none;
+        width: 150px;
+        height: 150px;
+}
+
 .youtube-video {
         position: relative;
         padding-bottom: 56.25%;

--- a/index.html
+++ b/index.html
@@ -48,6 +48,12 @@
           </a>
         </div>
 
+        <div class="instagram-tiles">
+          <iframe src="https://www.instagram.com/p/C1G52DXrX8x/embed" loading="lazy"></iframe>
+          <iframe src="https://www.instagram.com/p/C0z0JHTrh7L/embed" loading="lazy"></iframe>
+          <iframe src="https://www.instagram.com/p/C0zX9b4LVcE/embed" loading="lazy"></iframe>
+        </div>
+
         <div class="youtube-video" style="text-align:center; margin-top:20px;">
           <iframe width="560" height="315" src="https://www.youtube.com/embed/FDVtaBR8YVc" title="Cryptic Divination" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
         </div>


### PR DESCRIPTION
## Summary
- show three embedded Instagram posts under the follow button
- add tile styles for the embedded posts

## Testing
- `tidy -qe index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686945ea26f0832ebe797b0a098f250b