### PR TITLE
Fix button spacing

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -124,7 +124,7 @@ a.button-link {
     display:block;
     width:300px;
     text-align:center;
-    margin:0;
+    margin:10px auto;
 }
 
 .instagram-link a:hover {
@@ -135,7 +135,6 @@ a.button-link {
     display:flex;
     flex-direction:column;
     align-items:center;
-    gap:10px;
     margin:20px 0;
 }
 


### PR DESCRIPTION
## Summary
- adjust `.button-link` margin to match the Instagram button
- remove extra spacing from `.button-group`

## Testing
- `tidy -qe index.html`
- `tidy -qe shows.html`
- `tidy -qe about.html`


------
https://chatgpt.com/codex/tasks/task_e_68696107f974832e82e2684c6d307cff