### PR TITLE
Fix button gap on music links

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -107,7 +107,7 @@ footer a {
     display:block;
     width:300px;
     text-align:center;
-    margin:10px auto;
+    margin:0 auto 10px;
 }
 
 a.button-link {
@@ -124,7 +124,7 @@ a.button-link {
     display:block;
     width:300px;
     text-align:center;
-    margin:0;
+    margin:0 auto 10px;
 }
 
 .instagram-link a:hover {
@@ -135,8 +135,9 @@ a.button-link {
     display:flex;
     flex-direction:column;
     align-items:center;
-    gap:10px;
-    margin:20px 0;
+    gap:20px;
+    margin-top:20px;
+    margin-bottom:0;
 }
 
 a.button-link:hover {


### PR DESCRIPTION
## Summary
- add `gap: 20px` to `.button-group` so stacked buttons are evenly spaced

## Testing
- `tidy -qe index.html`
- `tidy -qe shows.html`
- `tidy -qe about.html`


------
https://chatgpt.com/codex/tasks/task_e_68696107f974832e82e2684c6d307cff