### PR TITLE
Add Flatulent Sermon show to schedule

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -65,6 +65,13 @@
       "venue": "John Henry's",
       "location": "Eugene, OR",
       "bands": ["Cryptic Divination", "Tithe", "Hallucinator"]
+    },
+    {
+      "date": "2025/12/13",
+      "venue": "John Henry's",
+      "location": "Eugene, OR",
+      "bands": ["Cryptic Divination", "Flatulent Sermon"],
+      "name": "Cryptic Divination and Flatulent Sermon"
     }
   ]
   </script>


### PR DESCRIPTION
## Summary
- add show with Cryptic Divination and Flatulent Sermon

## Testing
- `tidy -qe shows.html`


------
https://chatgpt.com/codex/tasks/task_e_6896dea639ec832e9d0139dd836b0ea3