### PR TITLE
Update August 18 show lineup

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -52,7 +52,7 @@
       "date": "2025/08/18",
       "venue": "John Henry's",
       "location": "Eugene, OR",
-      "bands": ["TBA"]
+      "bands": ["Cryptic Divination", "Flatulent Sermon"]
     },
     {
       "date": "2025/09/12",


### PR DESCRIPTION
## Summary
- Specify Cryptic Divination and Flatulent Sermon as bands for the August 18 show

## Testing
- `tidy -qe shows.html`

------
https://chatgpt.com/codex/tasks/task_e_6896e0c36e54832ea27e4476c0f6cf04