### PR TITLE
Swap Paralicyst and Cryptic Divination lineup order

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -58,7 +58,7 @@
       "date": "2025/09/12",
       "venue": "John Henry's",
       "location": "Eugene, OR",
-      "bands": ["Cryptic Divination", "Paralicyst", "Gravewitch"]
+      "bands": ["Paralicyst", "Cryptic Divination", "Gravewitch"]
     },
     {
       "date": "2025/11/06",


### PR DESCRIPTION
## Summary
- Swap Paralicyst ahead of Cryptic Divination in the September 12, 2025 show lineup

## Testing
- `tidy -qe shows.html`


------
https://chatgpt.com/codex/tasks/task_e_689a81a1c894832eaa6f942286201fc2