### PR TITLE
Rename Aug 18 show and reorder lineup

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -52,7 +52,8 @@
       "date": "2025/08/18",
       "venue": "John Henry's",
       "location": "Eugene, OR",
-      "bands": ["Cryptic Divination", "Flatulent Sermon"]
+      "bands": ["Mike Scheidt", "Flatulent Sermon", "Cryptic Divination"],
+      "name": "Masako Poole Celebration of Life"
     },
     {
       "date": "2025/09/12",


### PR DESCRIPTION
## Summary
- Rename Aug 18 2025 show to Masako Poole Celebration of Life
- List Mike Scheidt and Flatulent Sermon before Cryptic Divination

## Testing
- `tidy -qe shows.html`

------
https://chatgpt.com/codex/tasks/task_e_68a3ebc88188832e908e39cba317f059