### PR TITLE
Add October 18 show at The Side Pocket

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -62,6 +62,12 @@
       "bands": ["Cryptic Divination", "Paralicyst", "Gravewitch"]
     },
     {
+      "date": "2025/10/18",
+      "venue": "The Side Pocket",
+      "location": "Eugene, OR",
+      "bands": ["Cryptic Divination", "Ausekara", "Back from Death"]
+    },
+    {
       "date": "2025/11/06",
       "venue": "John Henry's",
       "location": "Eugene, OR",


### PR DESCRIPTION
## Summary
- add October 18 show at The Side Pocket in Eugene with lineup Cryptic Divination, Ausekara, Back from Death

## Testing
- `tidy -qe shows.html`


------
https://chatgpt.com/codex/tasks/task_e_68bb63884ab0832e8492c390e9553f5d