### PR TITLE
Update October 18 show lineup

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -65,7 +65,7 @@
       "date": "2025/10/18",
       "venue": "The Side Pocket",
       "location": "Eugene, OR",
-      "bands": ["Cryptic Divination", "Ausekara", "Back from Death"]
+      "bands": ["Cronoslag", "Flatulent Sermon", "Cryptic Divination", "Back from Death"]
     },
     {
       "date": "2025/11/06",


### PR DESCRIPTION
## Summary
- Replace Ausekara with Cronoslag and Flatulent Sermon for the October 18 Side Pocket show, placing Cryptic Divination after them

## Testing
- `tidy -qe shows.html`


------
https://chatgpt.com/codex/tasks/task_e_68c5a93ff2b4832ebc687da887d1cb83