### PR TITLE
Correct Blast Off Vintage show details

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -8,6 +8,13 @@
   <script id="show-data" type="application/json">
   [
     {
+      "date": "2024/10/26",
+      "venue": "Blast Off Vintage",
+      "location": "Salem, OR",
+      "bands": ["Oddities", "Cryptic Divination", "Within Caskets"],
+      "info": "All ages"
+    },
+    {
       "date": "2025/02/04",
       "venue": "John Henry's",
       "location": "Eugene, OR",


### PR DESCRIPTION
## Summary
- add the October 26, 2024 lineup featuring Within Caskets as headliner
- include all-ages note for the Blast Off Vintage event and correct venue/band listing

## Testing
- tidy -qe shows.html

------
https://chatgpt.com/codex/tasks/task_e_68e1cb1770a0832e9304d28d338f80c7