### PR TITLE
Fix Blast Off Vintage show year

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -8,6 +8,13 @@
   <script id="show-data" type="application/json">
   [
     {
+      "date": "2025/10/26",
+      "venue": "Blast Off Vintage",
+      "location": "Salem, OR",
+      "bands": ["Oddities", "Cryptic Divination", "Within Caskets"],
+      "info": "All ages"
+    },
+    {
       "date": "2025/02/04",
       "venue": "John Henry's",
       "location": "Eugene, OR",


### PR DESCRIPTION
## Summary
- update the Blast Off Vintage show entry to use the 2025 date

## Testing
- tidy -qe shows.html

------
https://chatgpt.com/codex/tasks/task_e_68e1cb1770a0832e9304d28d338f80c7