### PR TITLE
Group past shows by year with collapsible sections

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -206,6 +206,31 @@ footer a {
   gap: 0.75rem;
 }
 
+#past-shows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.past-year-group {
+  width: min(880px, 100%);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.72);
+  padding: 0.8rem 1rem;
+}
+
+.past-year-summary {
+  cursor: pointer;
+  font-weight: bold;
+  text-align: center;
+  letter-spacing: 0.08em;
+}
+
+.past-year-list {
+  margin-top: 0.8rem;
+}
+
 .show-entry {
   width: min(880px, 100%);
   border: 1px solid var(--line);

--- a/assets/style.css
+++ b/assets/style.css
@@ -225,6 +225,11 @@ footer a {
   font-weight: bold;
   text-align: center;
   letter-spacing: 0.08em;
+  list-style: none;
+}
+
+.past-year-summary::-webkit-details-marker {
+  display: none;
 }
 
 .past-year-list {

--- a/shows.html
+++ b/shows.html
@@ -168,7 +168,7 @@
       <ul id="upcoming-shows"></ul>
 
       <h2 id="past">Past Shows</h2>
-      <ul id="past-shows"></ul>
+      <div id="past-shows"></div>
     </section>
   </main>
 
@@ -181,16 +181,57 @@
     const today = new Date();
     const todayStart = new Date(today);
     todayStart.setHours(0, 0, 0, 0);
+    const upcomingHeading = document.getElementById('upcoming');
+    const pastHeading = document.getElementById('past');
     const upcomingList = document.getElementById('upcoming-shows');
-    const pastList = document.getElementById('past-shows');
+    const pastContainer = document.getElementById('past-shows');
 
     shows.sort((a, b) => new Date(b.date) - new Date(a.date));
     const upcoming = shows.filter((show) => new Date(show.date) >= todayStart);
     upcoming.reverse();
     const past = shows.filter((show) => new Date(show.date) < todayStart);
 
-    upcoming.concat(past).forEach((show) => {
+    upcomingHeading.textContent = `Upcoming Shows (${upcoming.length})`;
+    pastHeading.textContent = `Past Shows (${past.length})`;
+
+    upcoming.forEach((show) => {
       const showDate = new Date(show.date);
+      if (showDate >= todayStart) {
+        upcomingList.appendChild(createShowEntry(show));
+      }
+    });
+
+    const pastShowsByYear = past.reduce((groups, show) => {
+      const year = new Date(show.date).getFullYear();
+      if (!groups[year]) {
+        groups[year] = [];
+      }
+      groups[year].push(show);
+      return groups;
+    }, {});
+
+    Object.keys(pastShowsByYear)
+      .sort((a, b) => Number(b) - Number(a))
+      .forEach((year) => {
+        const yearSection = document.createElement('details');
+        yearSection.className = 'past-year-group';
+
+        const yearSummary = document.createElement('summary');
+        yearSummary.className = 'past-year-summary';
+        yearSummary.textContent = `${year} (${pastShowsByYear[year].length})`;
+
+        const yearList = document.createElement('ul');
+        yearList.className = 'past-year-list';
+        pastShowsByYear[year].forEach((show) => {
+          yearList.appendChild(createShowEntry(show));
+        });
+
+        yearSection.appendChild(yearSummary);
+        yearSection.appendChild(yearList);
+        pastContainer.appendChild(yearSection);
+      });
+
+    function createShowEntry(show) {
       const displayOrder = [...show.bands];
       displayOrder.reverse();
       const summaryText = `${formatDate(show.date)} - ${show.name ? `${show.name} - ` : ''}${displayOrder.join(', ')} - ${show.venue} - ${show.location}`;
@@ -229,13 +270,8 @@
 
       li.appendChild(summary);
       li.appendChild(details);
-
-      if (showDate >= todayStart) {
-        upcomingList.appendChild(li);
-      } else {
-        pastList.appendChild(li);
-      }
-    });
+      return li;
+    }
 
     function formatDate(dateStr) {
       const options = { year: 'numeric', month: 'short', day: 'numeric' };


### PR DESCRIPTION
### Motivation
- Make the Shows page show counts next to the `Upcoming` and `Past` headings and organize past shows by year for easier browsing.
- Present past-year groups collapsed by default so the list is compact but expandable on demand.

### Description
- Update `shows.html` to set `Upcoming Shows (N)` and `Past Shows (N)` and replace the old past `ul` with a `div` container `#past-shows`.
- Group past shows by year using a JS reducer and render each year as a collapsed `<details>` section with a `<summary>` like `2025 (count)`.
- Refactor per-show rendering into a reusable `createShowEntry(show)` function used for both upcoming and past lists, preserving the existing per-show expand/collapse behavior.
- Add styles in `assets/style.css` for `#past-shows`, `.past-year-group`, `.past-year-summary`, and `.past-year-list` to match the site theme.

### Testing
- Ran `tidy -qe shows.html` which completed successfully.
- Attempted a Playwright screenshot to visually verify the page, but the browser container could not reach the local static server in this environment and the capture failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aef71055e0832e91a4629e268f407a)