### PR TITLE
Update 2026/05/01 show lineup to Redivivus

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -53,7 +53,7 @@
       "date": "2026/05/01",
       "venue": "Bombs Away Cafe",
       "location": "Corvallis, OR",
-      "bands": ["Cryptic Divination", "Fosphene", "Gathering"]
+      "bands": ["Cryptic Divination", "Redivivus", "Gathering"]
     },
     {
       "date": "2026/05/03",


### PR DESCRIPTION
### Motivation
- Replace Fosphene with Redivivus for the Bombs Away Cafe show on `2026/05/01` to reflect the updated lineup.

### Description
- Change the `bands` array for the `2026/05/01` entry in `shows.html` from `["Cryptic Divination", "Fosphene", "Gathering"]` to `["Cryptic Divination", "Redivivus", "Gathering"]`.

### Testing
- Ran `tidy -qe shows.html` with no errors, served the site via `python3 -m http.server 4173` and captured a verification screenshot with Playwright, all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07540b304832eaae64a7943412a43)