### PR TITLE
Add June 19, 2026 John Henry's show lineup

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -62,6 +62,12 @@
       "bands": ["Cryptic Divination", "Fosphene", "Gathering"]
     },
     {
+      "date": "2026/06/19",
+      "venue": "John Henry's",
+      "location": "Eugene, OR",
+      "bands": ["Cryptic Divination", "Gamma Knife", "Gürschach", "Nox Sinister"]
+    },
+    {
       "date": "2025/06/21",
       "venue": "John Henry's",
       "location": "Eugene, OR",


### PR DESCRIPTION
### Motivation
- Add a new upcoming show date and capture the playing-order lineup for the John Henry's event on June 19, 2026.

### Description
- Inserted a JSON show entry in `shows.html` for `2026/06/19` at `John Henry's` in Eugene, OR with `bands` ordered as ["Cryptic Divination", "Gamma Knife", "Gürschach", "Nox Sinister"].

### Testing
- Ran `tidy -qe shows.html` and it completed successfully with no reported markup issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa9708b90832e9ac9be29ecf4320b)