### PR TITLE
Add About page with centered logo, band photo, members and bio

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,17 +9,17 @@
 </head>
 <body class="about-page">
   <main class="about-layout">
+    <nav class="about-control-bar" aria-label="About page controls">
+      <a href="index.html">Home</a>
+      <a href="shows.html">Shows</a>
+      <a href="https://instagram.com/crypticdivination" target="_blank" rel="noopener noreferrer">Instagram</a>
+      <a href="mailto:crypticdivination@gmail.com">Contact</a>
+    </nav>
+
     <section class="about-hero" aria-label="Band hero image">
       <img src="assets/Cryptic_Divination_Band_Photo_Website.jpg" alt="Cryptic Divination band photo" class="about-hero-image">
 
       <div class="about-overlay">
-        <nav class="about-control-bar" aria-label="About page controls">
-          <a href="index.html">Home</a>
-          <a href="shows.html">Shows</a>
-          <a href="https://instagram.com/crypticdivination" target="_blank" rel="noopener noreferrer">Instagram</a>
-          <a href="mailto:crypticdivination@gmail.com">Contact</a>
-        </nav>
-
         <img src="assets/Cryptic%20Divination%20N%20L%20W.png" alt="Cryptic Divination logo" class="about-overlay-logo">
       </div>
     </section>

--- a/about.html
+++ b/about.html
@@ -13,14 +13,14 @@
       <img src="assets/Cryptic_Divination_Band_Photo_Website.jpg" alt="Cryptic Divination band photo" class="about-hero-image">
 
       <div class="about-overlay">
-        <img src="assets/Cryptic%20Divination%20N%20L%20W.png" alt="Cryptic Divination logo" class="about-overlay-logo">
-
         <nav class="about-control-bar" aria-label="About page controls">
           <a href="index.html">Home</a>
           <a href="shows.html">Shows</a>
           <a href="https://instagram.com/crypticdivination" target="_blank" rel="noopener noreferrer">Instagram</a>
           <a href="mailto:crypticdivination@gmail.com">Contact</a>
         </nav>
+
+        <img src="assets/Cryptic%20Divination%20N%20L%20W.png" alt="Cryptic Divination logo" class="about-overlay-logo">
       </div>
     </section>
 
@@ -35,7 +35,6 @@
     </section>
 
     <section class="about-bio" aria-label="Band bio">
-      <h2>Bio</h2>
       <p>Influenced by bands like Opeth and Cynic, Cryptic Divination is a unique "second generation" of sounds from '90s death metal to '70s prog rock. Utilizing heavy riffs, clean sections and screams, they embody a new wave of pacific-northwest progressive death metal.</p>
     </section>
   </main>

--- a/about.html
+++ b/about.html
@@ -8,18 +8,19 @@
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body class="about-page">
-  <div class="shows-background" aria-hidden="true"></div>
+  <main class="about-layout">
+    <section class="about-hero" aria-label="Band hero image">
+      <img src="assets/Cryptic_Divination_Band_Photo_Website.jpg" alt="Cryptic Divination band photo" class="about-hero-image">
 
-  <main class="v2-page">
-    <section class="logo-section" aria-label="Band logo">
-      <div class="logo-crop">
-        <img src="assets/Cryptic%20Divination%20N%20E%20W.png" alt="Cryptic Divination new logo" class="logo-image">
-      </div>
-    </section>
+      <div class="about-overlay">
+        <img src="assets/Cryptic%20Divination%20N%20L%20W.png" alt="Cryptic Divination logo" class="about-overlay-logo">
 
-    <section class="photo-section" aria-label="Band photo">
-      <div class="band-photo-crop">
-        <img src="assets/Cryptic_Divination_Band_Photo_Website.jpg" alt="Cryptic Divination band photo" class="band-photo">
+        <nav class="about-control-bar" aria-label="About page controls">
+          <a href="index.html">Home</a>
+          <a href="shows.html">Shows</a>
+          <a href="https://instagram.com/crypticdivination" target="_blank" rel="noopener noreferrer">Instagram</a>
+          <a href="mailto:crypticdivination@gmail.com">Contact</a>
+        </nav>
       </div>
     </section>
 
@@ -37,11 +38,6 @@
       <h2>Bio</h2>
       <p>Influenced by bands like Opeth and Cynic, Cryptic Divination is a unique "second generation" of sounds from '90s death metal to '70s prog rock. Utilizing heavy riffs, clean sections and screams, they embody a new wave of pacific-northwest progressive death metal.</p>
     </section>
-
-    <nav class="links" aria-label="Page links">
-      <a href="index.html">Home</a>
-      <a href="shows.html">Shows</a>
-    </nav>
   </main>
 
   <footer>

--- a/about.html
+++ b/about.html
@@ -1,30 +1,51 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="About Cryptic Divination">
   <title>Cryptic Divination - About</title>
   <link rel="stylesheet" href="assets/style.css">
 </head>
-<body>
-    <header><h1>CRYPTIC DIVINATION</h1></header>
-  <nav>
-    <a href="index.html">Home</a>
-  </nav>
+<body class="about-page">
+  <div class="shows-background" aria-hidden="true"></div>
 
-    <section id="about" class="about">
-        <h2>About Us</h2>
-        <!-- <p>Cryptic Divination has been prophesizing the audible apocalypse since 2024.</p> -->
-        <img src="assets/IMG_6328_cropped.jpg" width="3600" alt="Band Photo">
-        <p>Chris - Drums</p> 
-        <p>Jesse - Bass</p>
-        <p>Naookie - Guitar</p>
-        <p>Sebastian - Guitar/Vocals</p>
+  <main class="v2-page">
+    <section class="logo-section" aria-label="Band logo">
+      <div class="logo-crop">
+        <img src="assets/Cryptic%20Divination%20N%20E%20W.png" alt="Cryptic Divination new logo" class="logo-image">
+      </div>
     </section>
 
+    <section class="photo-section" aria-label="Band photo">
+      <div class="band-photo-crop">
+        <img src="assets/Cryptic_Divination_Band_Photo_Website.jpg" alt="Cryptic Divination band photo" class="band-photo">
+      </div>
+    </section>
+
+    <section class="about-members" aria-label="Band members">
+      <h2>Members</h2>
+      <ul>
+        <li>Chris &mdash; Drums</li>
+        <li>Jesse &mdash; Bass</li>
+        <li>Naookie &mdash; Guitar</li>
+        <li>Sebastian &mdash; Guitar / Vocals</li>
+      </ul>
+    </section>
+
+    <section class="about-bio" aria-label="Band bio">
+      <h2>Bio</h2>
+      <p>Influenced by bands like Opeth and Cynic, Cryptic Divination is a unique "second generation" of sounds from '90s death metal to '70s prog rock. Utilizing heavy riffs, clean sections and screams, they embody a new wave of pacific-northwest progressive death metal.</p>
+    </section>
+
+    <nav class="links" aria-label="Page links">
+      <a href="index.html">Home</a>
+      <a href="shows.html">Shows</a>
+    </nav>
+  </main>
 
   <footer>
-    <p>&copy; 2024 Cryptic Divination. All rights reserved. | Follow us on <a href="https://www.instagram.com/crypticdivination/" target="_blank">Instagram</a> and <a href="https://www.youtube.com/@crypticdivination1886" target="_blank">YouTube</a>.</p>
+    <p>&copy; 2024 Cryptic Divination. All rights reserved. | Follow us on <a href="https://www.instagram.com/crypticdivination/" target="_blank" rel="noopener noreferrer">Instagram</a> and <a href="https://www.youtube.com/@crypticdivination1886" target="_blank" rel="noopener noreferrer">YouTube</a>.</p>
   </footer>
 </body>
 </html>

--- a/assets/style.css
+++ b/assets/style.css
@@ -270,3 +270,37 @@ footer a {
 .show-details a {
   color: #bfc7ff;
 }
+
+.about-page {
+  position: relative;
+}
+
+.about-members,
+.about-bio {
+  width: min(960px, 100%);
+  border: 1px solid var(--line);
+  background: rgba(0, 0, 0, 0.78);
+  padding: 1rem 1.25rem;
+}
+
+.about-members h2,
+.about-bio h2 {
+  margin-top: 0;
+  text-align: center;
+  letter-spacing: 0.08em;
+}
+
+.about-members ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+  text-align: center;
+}
+
+.about-bio p {
+  margin: 0;
+  line-height: 1.5;
+  text-align: center;
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -309,7 +309,6 @@ footer a {
   top: 5%;
   left: 50%;
   width: 55%;
-  max-width: 620px;
   transform: translate(-50%, -5%);
   filter: drop-shadow(0 0 20px rgba(0, 0, 0, 0.85));
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -301,19 +301,16 @@ footer a {
 .about-overlay {
   position: absolute;
   inset: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   pointer-events: none;
-  justify-content: flex-start;
 }
 
 .about-overlay-logo {
+  position: absolute;
+  top: 5%;
+  left: 50%;
   width: 55%;
   max-width: 620px;
-  min-width: 220px;
-  margin: 0.8rem auto 0;
-  transform: translateY(-5%);
+  transform: translate(-50%, -5%);
   filter: drop-shadow(0 0 20px rgba(0, 0, 0, 0.85));
 }
 
@@ -370,10 +367,6 @@ footer a {
 }
 
 @media (max-width: 640px) {
-  .about-overlay-logo {
-    margin-top: 0.55rem;
-  }
-
   .about-control-bar {
     gap: 0.4rem;
     padding: 0.45rem;

--- a/assets/style.css
+++ b/assets/style.css
@@ -308,8 +308,8 @@ footer a {
   position: absolute;
   top: 5%;
   left: 50%;
-  width: 55%;
-  transform: translate(-50%, -5%);
+  width: 38.5%;
+  transform: translate(-50%, -35%);
   filter: drop-shadow(0 0 20px rgba(0, 0, 0, 0.85));
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -271,13 +271,74 @@ footer a {
   color: #bfc7ff;
 }
 
+
 .about-page {
   position: relative;
+  padding-bottom: 0;
+}
+
+.about-layout {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.about-hero {
+  position: relative;
+  width: 100%;
+  border: 1px solid var(--line);
+}
+
+.about-hero-image {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.about-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;
+}
+
+.about-overlay-logo {
+  width: clamp(260px, 55vw, 620px);
+  max-width: 90%;
+  margin: 1.2rem auto 0;
+  filter: drop-shadow(0 0 20px rgba(0, 0, 0, 0.85));
+}
+
+.about-control-bar {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.6rem;
+  padding: 0.6rem;
+  background: rgba(0, 0, 0, 0.6);
+  pointer-events: auto;
+}
+
+.about-control-bar a {
+  color: var(--fg);
+  text-decoration: none;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(0, 0, 0, 0.65);
+  padding: 0.45rem 0.8rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  font-size: clamp(0.68rem, 1.35vw, 0.85rem);
 }
 
 .about-members,
 .about-bio {
-  width: min(960px, 100%);
+  width: 100%;
   border: 1px solid var(--line);
   background: rgba(0, 0, 0, 0.78);
   padding: 1rem 1.25rem;
@@ -304,3 +365,19 @@ footer a {
   line-height: 1.5;
   text-align: center;
 }
+
+@media (max-width: 640px) {
+  .about-layout {
+    padding: 0.5rem;
+  }
+
+  .about-overlay-logo {
+    margin-top: 0.55rem;
+  }
+
+  .about-control-bar {
+    gap: 0.4rem;
+    padding: 0.45rem;
+  }
+}
+

--- a/assets/style.css
+++ b/assets/style.css
@@ -297,6 +297,7 @@ footer a {
   display: block;
   width: 100%;
   height: auto;
+  margin-top: -10%;
 }
 
 .about-overlay {
@@ -304,14 +305,14 @@ footer a {
   inset: 0;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  align-items: center;
   pointer-events: none;
 }
 
 .about-overlay-logo {
   width: clamp(260px, 55vw, 620px);
   max-width: 90%;
-  margin: 1.2rem auto 0;
+  margin: clamp(1rem, 6vw, 4rem) auto 0;
   filter: drop-shadow(0 0 20px rgba(0, 0, 0, 0.85));
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -296,9 +296,7 @@ footer a {
 .about-hero-image {
   display: block;
   width: 100%;
-  height: clamp(420px, 72vw, 900px);
-  object-fit: cover;
-  object-position: center 32%;
+  height: auto;
 }
 
 .about-overlay {
@@ -314,7 +312,6 @@ footer a {
   width: clamp(260px, 55vw, 620px);
   max-width: 90%;
   margin: 1.2rem auto 0;
-  transform: translateY(-50%);
   filter: drop-shadow(0 0 20px rgba(0, 0, 0, 0.85));
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -89,7 +89,6 @@ footer {
 }
 
 .band-photo-crop .band-photo {
-  margin-top: -10%;
   margin-bottom: -25%;
 }
 
@@ -297,7 +296,6 @@ footer a {
   display: block;
   width: 100%;
   height: auto;
-  margin-top: -10%;
 }
 
 .about-overlay {
@@ -307,12 +305,15 @@ footer a {
   flex-direction: column;
   align-items: center;
   pointer-events: none;
+  justify-content: flex-start;
 }
 
 .about-overlay-logo {
-  width: clamp(260px, 55vw, 620px);
-  max-width: 90%;
-  margin: clamp(1rem, 6vw, 4rem) auto 0;
+  width: 55%;
+  max-width: 620px;
+  min-width: 220px;
+  margin: 0.8rem auto 0;
+  transform: translateY(-5%);
   filter: drop-shadow(0 0 20px rgba(0, 0, 0, 0.85));
 }
 
@@ -323,7 +324,7 @@ footer a {
   justify-content: center;
   gap: 0.6rem;
   padding: 0.6rem;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.75);
   pointer-events: auto;
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -278,9 +278,9 @@ footer a {
 }
 
 .about-layout {
-  width: min(1200px, 100%);
-  margin: 0 auto;
-  padding: 1rem;
+  width: 100%;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -288,14 +288,17 @@ footer a {
 
 .about-hero {
   position: relative;
-  width: 100%;
-  border: 1px solid var(--line);
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  overflow: hidden;
 }
 
 .about-hero-image {
   display: block;
   width: 100%;
-  height: auto;
+  height: clamp(420px, 72vw, 900px);
+  object-fit: cover;
+  object-position: center 32%;
 }
 
 .about-overlay {
@@ -311,6 +314,7 @@ footer a {
   width: clamp(260px, 55vw, 620px);
   max-width: 90%;
   margin: 1.2rem auto 0;
+  transform: translateY(-50%);
   filter: drop-shadow(0 0 20px rgba(0, 0, 0, 0.85));
 }
 
@@ -367,10 +371,6 @@ footer a {
 }
 
 @media (max-width: 640px) {
-  .about-layout {
-    padding: 0.5rem;
-  }
-
   .about-overlay-logo {
     margin-top: 0.55rem;
   }

--- a/assets/style.css
+++ b/assets/style.css
@@ -198,7 +198,7 @@ footer a {
 .shows-list ul {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 1rem 0 0;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -279,7 +279,7 @@ footer a {
 .about-layout {
   width: 100%;
   margin: 0;
-  padding: 0;
+  padding: 1rem 0 0;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -308,8 +308,8 @@ footer a {
   position: absolute;
   top: 5%;
   left: 50%;
-  width: 38.5%;
-  transform: translate(-50%, -35%);
+  width: 34.65%;
+  transform: translate(-50%, -25%);
   filter: drop-shadow(0 0 20px rgba(0, 0, 0, 0.85));
 }
 

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
 
     <section class="links" aria-label="Music and social links">
       <a href="shows.html">Shows</a>
+      <a href="about.html">About</a>
       <a href="https://cryptic-divination.printify.me/" target="_blank" rel="noopener noreferrer">Merch</a>
       <a href="https://instagram.com/crypticdivination" target="_blank" rel="noopener noreferrer">Instagram</a>
       <a href="https://open.spotify.com/artist/2Ospy7D5b96TFFR6KbAOx3" target="_blank" rel="noopener noreferrer">Spotify</a>


### PR DESCRIPTION
### Motivation
- Create a dedicated About page that leads with the new logo centered at the top and features the latest band photo as the hero image.
- Surface the band members and the provided bio text in a clear, consistent layout matching the existing site style.
- Keep site navigation and footer intact for consistency across pages.

### Description
- Add `about.html` which places `assets/Cryptic Divination N E W.png` at the top center, shows `assets/Cryptic_Divination_Band_Photo_Website.jpg` as the lead image, lists members, and includes the supplied bio text with `aria-label` attributes for accessibility.
- Add responsive styling for the new page by appending rules to `assets/style.css` for `.about-page`, `.about-members`, `.about-bio`, and related layout tweaks.
- Preserve the existing site navigation links and footer in `about.html` so the page remains consistent with the rest of the site.

### Testing
- Run `tidy -qe about.html` which completed successfully with no errors.
- No other automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff82eb3c4832ebf771eeb56997b8a)