### PR TITLE
Restore homepage logo and add Volume I release heading

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -85,7 +85,12 @@ footer {
 }
 
 .volume-heading {
-  margin: 0 0 0.75rem;
+  width: fit-content;
+  margin: 0 auto 0.75rem;
+  padding: 0.65rem 0.9rem;
+  background: #000;
+  border: 1px solid var(--line);
+  border-radius: 6px;
   text-align: center;
   letter-spacing: 0.06em;
   font-size: clamp(1rem, 2.6vw, 1.5rem);

--- a/assets/style.css
+++ b/assets/style.css
@@ -84,6 +84,13 @@ footer {
   border: 1px solid var(--line);
 }
 
+.volume-heading {
+  margin: 0 0 0.75rem;
+  text-align: center;
+  letter-spacing: 0.06em;
+  font-size: clamp(1rem, 2.6vw, 1.5rem);
+}
+
 .youtube-video iframe {
   width: 100%;
   border: 1px solid var(--line);

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <main class="v2-page">
     <section class="logo-section" aria-label="Cryptic Divination logo">
       <div class="logo-crop">
-        <img src="assets/cryptic_transparent_black.png" alt="Cryptic Divination logo" class="logo-image">
+        <img src="assets/Cryptic%20Divination%20N%20L%20W.png" alt="Cryptic Divination N L W logo" class="logo-image">
       </div>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -10,6 +10,12 @@
 <body class="home-page">
   <div class="shows-background" aria-hidden="true"></div>
   <main class="v2-page">
+    <section class="logo-section" aria-label="Cryptic Divination logo">
+      <div class="logo-crop">
+        <img src="assets/cryptic_transparent_black.png" alt="Cryptic Divination logo" class="logo-image">
+      </div>
+    </section>
+
     <section class="links" aria-label="Music and social links">
       <a href="shows.html">Shows</a>
       <a href="about.html">About</a>
@@ -21,6 +27,7 @@
     </section>
 
     <section class="photo-section" aria-label="Volume I photo">
+      <h2 class="volume-heading">Volume I, out April 30th, 2026. Available for pre-order now</h2>
       <img src="assets/Cryptic_Divination_Volume_I.jpg" alt="Cryptic Divination Volume I photo" class="band-photo">
     </section>
 


### PR DESCRIPTION
### Motivation
- Reintroduce the site logo to the homepage to restore brand identity above the main links. 
- Surface the Volume I release and pre-order messaging above the album image so visitors see the release date immediately.

### Description
- Added a new `logo-section` to `index.html` that displays `assets/cryptic_transparent_black.png` using the existing logo layout classes. 
- Inserted an `h2` with the copy "Volume I, out April 30th, 2026. Available for pre-order now" above the `assets/Cryptic_Divination_Volume_I.jpg` image in `index.html`. 
- Added `.volume-heading` rules to `assets/style.css` to center the heading and make the font-size responsive with `clamp()`.

### Testing
- Ran `tidy -qe index.html` to validate the modified HTML and it completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e01ab8f06c832eb32bacaaf9016495)