### PR TITLE
Add Cataclasis art section below Volume I

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,11 @@
       <img src="assets/Cryptic_Divination_Volume_I.jpg" alt="Cryptic Divination Volume I photo" class="band-photo">
     </section>
 
+    <section class="photo-section" aria-label="Cataclasis cover art">
+      <h2 class="volume-heading">Cataclasis - Single, available free for stream and download</h2>
+      <img src="assets/Cryptic%20Divination_JAN%202025.jpg" alt="Cataclasis single cover art" class="band-photo">
+    </section>
+
     <div class="youtube-video" aria-label="Cryptic Divination YouTube video">
       <iframe width="560" height="315" src="https://www.youtube.com/embed/FDVtaBR8YVc" title="Cryptic Divination" frameborder="0" allowfullscreen></iframe>
     </div>


### PR DESCRIPTION
### Motivation
- Surface the Cataclasis single on the homepage by placing its cover art and descriptive heading directly beneath the existing Volume I artwork so visitors can stream/download the track.

### Description
- Modify `index.html` to insert a new `<section>` with the heading `Cataclasis - Single, available free for stream and download` and an image element pointing to the existing Cataclasis cover asset with appropriate `aria-label` and `alt` text.

### Testing
- Ran `tidy -qe index.html` on the modified file and it returned no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e021e78bc4832e96cd6e7d723d7033)