### PR TITLE
Pin mobile audio player to viewport bottom

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -20,7 +20,7 @@ body {
   background: var(--bg);
   color: var(--fg);
   font-family: 'Cryptic', sans-serif;
-  padding-bottom: 90px;
+  padding-bottom: calc(90px + env(safe-area-inset-bottom, 0));
 }
 
 .v2-page {
@@ -114,9 +114,10 @@ footer a {
 
 .audio-player {
   position: fixed;
-  bottom: 0;
+  bottom: env(safe-area-inset-bottom, 0);
   left: 0;
   right: 0;
+  width: 100%;
   background: rgba(0, 0, 0, 0.9);
   padding: 10px 20px;
   display: flex;
@@ -135,6 +136,12 @@ footer a {
 .audio-player audio {
   flex: 1;
   max-width: 320px;
+}
+
+@supports (height: 100dvh) {
+  .home-page {
+    min-height: 100dvh;
+  }
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
### Motivation
- Fix the audio player so it remains anchored to the visible bottom edge on mobile devices with notches or dynamic browser chrome. 
- Prevent page content from being obscured by the fixed player and improve layout stability with dynamic viewport height changes.

### Description
- Update `body` bottom spacing to `padding-bottom: calc(90px + env(safe-area-inset-bottom, 0))` in `assets/style.css` so content clears the player. 
- Anchor `.audio-player` with `bottom: env(safe-area-inset-bottom, 0)` and add `width: 100%` to avoid layout drift on narrow mobile browsers. 
- Add an `@supports (height: 100dvh)` block to set `.home-page { min-height: 100dvh; }` to better align with dynamic mobile viewport behavior.

### Testing
- Ran `git diff --check` which returned no issues. 
- Committed the updated `assets/style.css` successfully. 
- No HTML files were modified, so `tidy -qe` was not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e023c860b0832eaccaecafb5ee44a1)