### PR TITLE
Update July 3 show lineup order

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -83,7 +83,7 @@
       "date": "2026/07/03",
       "venue": "John Henry's",
       "location": "Eugene, OR",
-      "bands": ["Cryptic Divination", "TBA"]
+      "bands": ["Maulrat", "Veil of Ashes", "Cryptic Divination"]
     },
     {
       "date": "2025/07/30",


### PR DESCRIPTION
### Motivation
- Update the July 3 John Henry's show entry to reflect the confirmed lineup order.

### Description
- Replace the July 3 `bands` array in `shows.html` from `["Cryptic Divination", "TBA"]` to `["Maulrat", "Veil of Ashes", "Cryptic Divination"]`.

### Testing
- Ran `tidy -qe shows.html` which completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f03240ead0832e9f39e6ed099d7e30)