### PR TITLE
Add dedicated music page

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -382,3 +382,113 @@ footer a {
     padding: 0.45rem;
   }
 }
+
+.music-app {
+  width: min(960px, 100%);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(10, 10, 10, 0.88);
+  overflow: hidden;
+}
+
+.music-app-header {
+  padding: 1.1rem 1.25rem;
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(180deg, rgba(45, 45, 45, 0.5), rgba(0, 0, 0, 0.4));
+}
+
+.music-kicker {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.music-app-header h1 {
+  margin: 0.35rem 0 0;
+  font-size: clamp(1.1rem, 2.8vw, 1.8rem);
+  letter-spacing: 0.06em;
+}
+
+.music-service-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-bottom: 1px solid var(--line);
+}
+
+.music-service-tabs a {
+  text-align: center;
+  padding: 0.9rem 1rem;
+  text-transform: uppercase;
+  text-decoration: none;
+  letter-spacing: 0.08em;
+  color: var(--fg);
+  border-right: 1px solid var(--line);
+}
+
+.music-service-tabs a:last-child {
+  border-right: 0;
+}
+
+.music-service-tabs a:hover,
+.music-service-tabs a:focus-visible {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.music-track-list {
+  padding: 1rem 1.25rem 1.4rem;
+}
+
+.music-track-list h2 {
+  margin: 0 0 0.9rem;
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+}
+
+.track-row {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.85rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.8rem;
+  background: rgba(0, 0, 0, 0.75);
+}
+
+.track-meta {
+  min-width: 210px;
+}
+
+.track-name {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+}
+
+.track-subtitle {
+  margin: 0.2rem 0 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.track-row audio {
+  width: min(100%, 360px);
+}
+
+@media (max-width: 640px) {
+  .music-service-tabs {
+    grid-template-columns: 1fr;
+  }
+
+  .music-service-tabs a {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .music-service-tabs a:last-child {
+    border-bottom: 0;
+  }
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -413,7 +413,7 @@ footer a {
 
 .music-service-tabs {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   border-bottom: 1px solid var(--line);
 }
 

--- a/index.html
+++ b/index.html
@@ -30,6 +30,11 @@
       <img src="assets/Cryptic_Divination_Volume_I.jpg" alt="Cryptic Divination Volume I photo" class="band-photo">
     </section>
 
+    <section class="photo-section" aria-label="Cataclasis cover art">
+      <h2 class="volume-heading">Cataclasis - Single, available free for stream and download</h2>
+      <img src="assets/Cryptic%20Divination_JAN%202025.jpg" alt="Cataclasis single cover art" class="band-photo">
+    </section>
+
 
     <div class="youtube-video" aria-label="Cryptic Divination YouTube video">
       <iframe width="560" height="315" src="https://www.youtube.com/embed/FDVtaBR8YVc" title="Cryptic Divination" frameborder="0" allowfullscreen></iframe>
@@ -40,5 +45,12 @@
     <p>&copy; 2024 Cryptic Divination. All rights reserved. | Follow us on <a href="https://www.instagram.com/crypticdivination/" target="_blank" rel="noopener noreferrer">Instagram</a> and <a href="https://www.youtube.com/@crypticdivination1886" target="_blank" rel="noopener noreferrer">YouTube</a>.</p>
   </footer>
 
+  <div class="audio-player" aria-label="Cataclasis audio player">
+    <p class="track-title">Cataclasis</p>
+    <audio controls preload="metadata">
+      <source src="assets/Cryptic%20Divination%20-%20Cataclasis.wav" type="audio/wav">
+      Your browser does not support the audio element.
+    </audio>
+  </div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -21,8 +21,7 @@
       <a href="about.html">About</a>
       <a href="https://cryptic-divination.printify.me/" target="_blank" rel="noopener noreferrer">Merch</a>
       <a href="https://instagram.com/crypticdivination" target="_blank" rel="noopener noreferrer">Instagram</a>
-      <a href="https://open.spotify.com/artist/2Ospy7D5b96TFFR6KbAOx3" target="_blank" rel="noopener noreferrer">Spotify</a>
-      <a href="https://music.apple.com/us/artist/cryptic-divination/1592862632" target="_blank" rel="noopener noreferrer">Apple Music</a>
+      <a href="music.html">Music</a>
       <a href="mailto:crypticdivination@gmail.com">Contact</a>
     </section>
 
@@ -31,10 +30,6 @@
       <img src="assets/Cryptic_Divination_Volume_I.jpg" alt="Cryptic Divination Volume I photo" class="band-photo">
     </section>
 
-    <section class="photo-section" aria-label="Cataclasis cover art">
-      <h2 class="volume-heading">Cataclasis - Single, available free for stream and download</h2>
-      <img src="assets/Cryptic%20Divination_JAN%202025.jpg" alt="Cataclasis single cover art" class="band-photo">
-    </section>
 
     <div class="youtube-video" aria-label="Cryptic Divination YouTube video">
       <iframe width="560" height="315" src="https://www.youtube.com/embed/FDVtaBR8YVc" title="Cryptic Divination" frameborder="0" allowfullscreen></iframe>
@@ -45,12 +40,5 @@
     <p>&copy; 2024 Cryptic Divination. All rights reserved. | Follow us on <a href="https://www.instagram.com/crypticdivination/" target="_blank" rel="noopener noreferrer">Instagram</a> and <a href="https://www.youtube.com/@crypticdivination1886" target="_blank" rel="noopener noreferrer">YouTube</a>.</p>
   </footer>
 
-  <div class="audio-player" aria-label="Cataclasis audio player">
-    <p class="track-title">Cataclasis</p>
-    <audio controls preload="metadata">
-      <source src="assets/Cryptic%20Divination%20-%20Cataclasis.wav" type="audio/wav">
-      Your browser does not support the audio element.
-    </audio>
-  </div>
 </body>
 </html>

--- a/music.html
+++ b/music.html
@@ -34,6 +34,11 @@
         <a href="https://open.spotify.com/artist/2Ospy7D5b96TFFR6KbAOx3" target="_blank" rel="noopener noreferrer">Spotify</a>
         <a href="https://crypticdivination.bandcamp.com/" target="_blank" rel="noopener noreferrer">Bandcamp</a>
       </div>
+
+      <section class="photo-section" aria-label="Cataclasis cover art">
+        <h2 class="volume-heading">Cataclasis - Single, available free for stream and download</h2>
+        <img src="assets/Cryptic%20Divination_JAN%202025.jpg" alt="Cataclasis single cover art" class="band-photo">
+      </section>
     </section>
   </main>
 

--- a/music.html
+++ b/music.html
@@ -32,26 +32,21 @@
       <div class="music-service-tabs" aria-label="Streaming services">
         <a href="https://music.apple.com/us/artist/cryptic-divination/1592862632" target="_blank" rel="noopener noreferrer">Apple Music</a>
         <a href="https://open.spotify.com/artist/2Ospy7D5b96TFFR6KbAOx3" target="_blank" rel="noopener noreferrer">Spotify</a>
+        <a href="https://crypticdivination.bandcamp.com/" target="_blank" rel="noopener noreferrer">Bandcamp</a>
       </div>
-
-      <section class="music-track-list" aria-label="Track list">
-        <h2>Singles</h2>
-        <article class="track-row" aria-label="Cataclasis track">
-          <div class="track-meta">
-            <p class="track-name">Cataclasis</p>
-            <p class="track-subtitle">Cryptic Divination</p>
-          </div>
-          <audio controls preload="metadata">
-            <source src="assets/Cryptic%20Divination%20-%20Cataclasis.wav" type="audio/wav">
-            Your browser does not support the audio element.
-          </audio>
-        </article>
-      </section>
     </section>
   </main>
 
   <footer>
     <p>&copy; 2024 Cryptic Divination. All rights reserved. | Follow us on <a href="https://www.instagram.com/crypticdivination/" target="_blank" rel="noopener noreferrer">Instagram</a> and <a href="https://www.youtube.com/@crypticdivination1886" target="_blank" rel="noopener noreferrer">YouTube</a>.</p>
   </footer>
+
+  <div class="audio-player" aria-label="Cataclasis audio player">
+    <p class="track-title">Cataclasis</p>
+    <audio controls preload="metadata">
+      <source src="assets/Cryptic%20Divination%20-%20Cataclasis.wav" type="audio/wav">
+      Your browser does not support the audio element.
+    </audio>
+  </div>
 </body>
 </html>

--- a/music.html
+++ b/music.html
@@ -21,26 +21,37 @@
       <a href="index.html">Home</a>
       <a href="shows.html">Shows</a>
       <a href="about.html">About</a>
-      <a href="https://open.spotify.com/artist/2Ospy7D5b96TFFR6KbAOx3" target="_blank" rel="noopener noreferrer">Spotify</a>
-      <a href="https://music.apple.com/us/artist/cryptic-divination/1592862632" target="_blank" rel="noopener noreferrer">Apple Music</a>
     </nav>
 
-    <section class="photo-section" aria-label="Cataclasis cover art">
-      <h1 class="volume-heading">Cataclasis - Single</h1>
-      <img src="assets/Cryptic%20Divination_JAN%202025.jpg" alt="Cataclasis single cover art" class="band-photo">
+    <section class="music-app" aria-label="Cryptic Divination streaming interface">
+      <header class="music-app-header">
+        <p class="music-kicker">Now Streaming</p>
+        <h1>Cryptic Divination Music</h1>
+      </header>
+
+      <div class="music-service-tabs" aria-label="Streaming services">
+        <a href="https://music.apple.com/us/artist/cryptic-divination/1592862632" target="_blank" rel="noopener noreferrer">Apple Music</a>
+        <a href="https://open.spotify.com/artist/2Ospy7D5b96TFFR6KbAOx3" target="_blank" rel="noopener noreferrer">Spotify</a>
+      </div>
+
+      <section class="music-track-list" aria-label="Track list">
+        <h2>Singles</h2>
+        <article class="track-row" aria-label="Cataclasis track">
+          <div class="track-meta">
+            <p class="track-name">Cataclasis</p>
+            <p class="track-subtitle">Cryptic Divination</p>
+          </div>
+          <audio controls preload="metadata">
+            <source src="assets/Cryptic%20Divination%20-%20Cataclasis.wav" type="audio/wav">
+            Your browser does not support the audio element.
+          </audio>
+        </article>
+      </section>
     </section>
   </main>
 
   <footer>
     <p>&copy; 2024 Cryptic Divination. All rights reserved. | Follow us on <a href="https://www.instagram.com/crypticdivination/" target="_blank" rel="noopener noreferrer">Instagram</a> and <a href="https://www.youtube.com/@crypticdivination1886" target="_blank" rel="noopener noreferrer">YouTube</a>.</p>
   </footer>
-
-  <div class="audio-player" aria-label="Cataclasis audio player">
-    <p class="track-title">Cataclasis</p>
-    <audio controls preload="metadata">
-      <source src="assets/Cryptic%20Divination%20-%20Cataclasis.wav" type="audio/wav">
-      Your browser does not support the audio element.
-    </audio>
-  </div>
 </body>
 </html>

--- a/music.html
+++ b/music.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Cryptic Divination music streaming">
+  <title>Cryptic Divination | Music</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body class="home-page">
+  <div class="shows-background" aria-hidden="true"></div>
+
+  <main class="v2-page">
+    <section class="logo-section" aria-label="Band logo">
+      <div class="logo-crop">
+        <img src="assets/Cryptic%20Divination%20N%20L%20W.png" alt="Cryptic Divination N L W logo" class="logo-image">
+      </div>
+    </section>
+
+    <nav class="links" aria-label="Music navigation">
+      <a href="index.html">Home</a>
+      <a href="shows.html">Shows</a>
+      <a href="about.html">About</a>
+      <a href="https://open.spotify.com/artist/2Ospy7D5b96TFFR6KbAOx3" target="_blank" rel="noopener noreferrer">Spotify</a>
+      <a href="https://music.apple.com/us/artist/cryptic-divination/1592862632" target="_blank" rel="noopener noreferrer">Apple Music</a>
+    </nav>
+
+    <section class="photo-section" aria-label="Cataclasis cover art">
+      <h1 class="volume-heading">Cataclasis - Single</h1>
+      <img src="assets/Cryptic%20Divination_JAN%202025.jpg" alt="Cataclasis single cover art" class="band-photo">
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; 2024 Cryptic Divination. All rights reserved. | Follow us on <a href="https://www.instagram.com/crypticdivination/" target="_blank" rel="noopener noreferrer">Instagram</a> and <a href="https://www.youtube.com/@crypticdivination1886" target="_blank" rel="noopener noreferrer">YouTube</a>.</p>
+  </footer>
+
+  <div class="audio-player" aria-label="Cataclasis audio player">
+    <p class="track-title">Cataclasis</p>
+    <audio controls preload="metadata">
+      <source src="assets/Cryptic%20Divination%20-%20Cataclasis.wav" type="audio/wav">
+      Your browser does not support the audio element.
+    </audio>
+  </div>
+</body>
+</html>

--- a/music.html
+++ b/music.html
@@ -35,9 +35,18 @@
         <a href="https://crypticdivination.bandcamp.com/" target="_blank" rel="noopener noreferrer">Bandcamp</a>
       </div>
 
-      <section class="photo-section" aria-label="Cataclasis cover art">
-        <h2 class="volume-heading">Cataclasis - Single, available free for stream and download</h2>
-        <img src="assets/Cryptic%20Divination_JAN%202025.jpg" alt="Cataclasis single cover art" class="band-photo">
+      <section class="music-track-list" aria-label="On-site music player">
+        <h2>Site Player</h2>
+        <article class="track-row" aria-label="Cataclasis track">
+          <div class="track-meta">
+            <p class="track-name">Cataclasis</p>
+            <p class="track-subtitle">Cryptic Divination</p>
+          </div>
+          <audio controls preload="metadata">
+            <source src="assets/Cryptic%20Divination%20-%20Cataclasis.wav" type="audio/wav">
+            Your browser does not support the audio element.
+          </audio>
+        </article>
       </section>
     </section>
   </main>
@@ -45,13 +54,5 @@
   <footer>
     <p>&copy; 2024 Cryptic Divination. All rights reserved. | Follow us on <a href="https://www.instagram.com/crypticdivination/" target="_blank" rel="noopener noreferrer">Instagram</a> and <a href="https://www.youtube.com/@crypticdivination1886" target="_blank" rel="noopener noreferrer">YouTube</a>.</p>
   </footer>
-
-  <div class="audio-player" aria-label="Cataclasis audio player">
-    <p class="track-title">Cataclasis</p>
-    <audio controls preload="metadata">
-      <source src="assets/Cryptic%20Divination%20-%20Cataclasis.wav" type="audio/wav">
-      Your browser does not support the audio element.
-    </audio>
-  </div>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a single page where visitors can stream the band's music and find external streaming links, and remove music clutter from the home page.
- Surface the single "Cataclasis" with cover art and an on-page audio player so listeners can stream it directly.

### Description
- Add a new `music.html` page containing cover art, an audio player for `assets/Cryptic Divination - Cataclasis.wav`, and external links to Spotify and Apple Music.
- Replace the direct Spotify and Apple Music links in `index.html` with a single `Music` link pointing to `music.html`.
- Remove the Cataclasis cover art section and the audio player from the home page so the track is only presented on the new music page.

### Testing
- Ran `tidy -qe index.html`, which completed successfully.
- Ran `tidy -qe music.html`, which completed successfully.
- Verified the changes were staged and committed (`git commit`), creating the new `music.html` and updating `index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e4ab6e3c832ebac2d69b2308f491)