### PR TITLE
Make Feigned Absolutions the home default and add Volume I

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,10 +44,10 @@
     <p>&copy; 2024 Cryptic Divination. All rights reserved. | Follow us on <a href="https://www.instagram.com/crypticdivination/" target="_blank" rel="noopener noreferrer">Instagram</a> and <a href="https://www.youtube.com/@crypticdivination1886" target="_blank" rel="noopener noreferrer">YouTube</a>.</p>
   </footer>
 
-  <div class="audio-player" aria-label="Cataclasis audio player">
-    <p class="track-title">Cataclasis</p>
+  <div class="audio-player" aria-label="Feigned Absolutions audio player">
+    <p class="track-title">Feigned Absolutions</p>
     <audio controls preload="metadata">
-      <source src="assets/Cryptic%20Divination%20-%20Cataclasis.wav" type="audio/wav">
+      <source src="assets/Cryptic%20Divination%20Volume%20I/1.%20Feigned%20Absolutions.wav" type="audio/wav">
       Your browser does not support the audio element.
     </audio>
   </div>

--- a/music.html
+++ b/music.html
@@ -37,6 +37,72 @@
 
       <section class="music-track-list" aria-label="On-site music player">
         <h2>Site Player</h2>
+        <h3>Volume I</h3>
+        <article class="track-row" aria-label="Feigned Absolutions track">
+          <div class="track-meta">
+            <p class="track-name">Feigned Absolutions</p>
+            <p class="track-subtitle">Volume I</p>
+          </div>
+          <audio controls preload="metadata">
+            <source src="assets/Cryptic%20Divination%20Volume%20I/1.%20Feigned%20Absolutions.wav" type="audio/wav">
+            Your browser does not support the audio element.
+          </audio>
+        </article>
+
+        <article class="track-row" aria-label="Capacity for Cruelty track">
+          <div class="track-meta">
+            <p class="track-name">Capacity for Cruelty</p>
+            <p class="track-subtitle">Volume I</p>
+          </div>
+          <audio controls preload="metadata">
+            <source src="assets/Cryptic%20Divination%20Volume%20I/2.%20Capacity%20for%20Cruelty.wav" type="audio/wav">
+            Your browser does not support the audio element.
+          </audio>
+        </article>
+
+        <article class="track-row" aria-label="Null Singularity track">
+          <div class="track-meta">
+            <p class="track-name">Null Singularity</p>
+            <p class="track-subtitle">Volume I</p>
+          </div>
+          <audio controls preload="metadata">
+            <source src="assets/Cryptic%20Divination%20Volume%20I/3.%20Null%20Singularity.wav" type="audio/wav">
+            Your browser does not support the audio element.
+          </audio>
+        </article>
+
+        <article class="track-row" aria-label="Purgatory of Contemplation track">
+          <div class="track-meta">
+            <p class="track-name">Purgatory of Contemplation</p>
+            <p class="track-subtitle">Volume I</p>
+          </div>
+          <audio controls preload="metadata">
+            <source src="assets/Cryptic%20Divination%20Volume%20I/4.%20Purgatory%20of%20Contemplation.wav" type="audio/wav">
+            Your browser does not support the audio element.
+          </audio>
+        </article>
+
+        <article class="track-row" aria-label="Delirium track">
+          <div class="track-meta">
+            <p class="track-name">Delirium</p>
+            <p class="track-subtitle">Volume I</p>
+          </div>
+          <audio controls preload="metadata">
+            <source src="assets/Cryptic%20Divination%20Volume%20I/5.%20Delirium.wav" type="audio/wav">
+            Your browser does not support the audio element.
+          </audio>
+        </article>
+
+        <article class="track-row" aria-label="Prison of Belief track">
+          <div class="track-meta">
+            <p class="track-name">Prison of Belief</p>
+            <p class="track-subtitle">Volume I</p>
+          </div>
+          <audio controls preload="metadata">
+            <source src="assets/Cryptic%20Divination%20Volume%20I/6.%20Prison%20of%20Belief.wav" type="audio/wav">
+            Your browser does not support the audio element.
+          </audio>
+        </article>
         <article class="track-row" aria-label="Cataclasis track">
           <div class="track-meta">
             <p class="track-name">Cataclasis</p>


### PR DESCRIPTION
### Motivation
- Volume I audio files were added to the repository and the site should expose the new release and use the intended default track on the home page.

### Description
- Updated `index.html` audio player to use the `Feigned Absolutions` track by changing the player label and source path to the Volume I file.
- Updated `music.html` to add a `Volume I` heading and six embedded site-player entries for the Volume I tracks (`Feigned Absolutions`, `Capacity for Cruelty`, `Null Singularity`, `Purgatory of Contemplation`, `Delirium`, and `Prison of Belief`).
- Left the existing `Cataclasis` single in the music list so both the single and the new album tracks are available on the site player.

### Testing
- Ran `tidy -qe index.html` and it returned success (no markup errors).
- Ran `tidy -qe music.html` and it returned success (no markup errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38f0fe274832e843d50d3bf0d8549)