### PR TITLE
Keep shows data with page content for SPA nav

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -6,6 +6,37 @@
   <meta name="description" content="Cryptic Divination shows and live dates" />
   <title>Cryptic Divination | Shows</title>
   <link rel="stylesheet" href="assets/style.css">
+  
+</head>
+<body class="shows-page">
+  <div class="shows-background" aria-hidden="true"></div>
+
+  <main class="v2-page">
+    <section class="logo-section" aria-label="Band logo">
+      <div class="logo-crop">
+        <img src="assets/Cryptic%20Divination%20N%20L%20W.png" alt="Cryptic Divination N L W logo" class="logo-image">
+      </div>
+    </section>
+
+    <nav class="links" aria-label="Shows navigation">
+      <a href="index.html">Home</a>
+      <a href="#upcoming">Upcoming</a>
+      <a href="#past">Past</a>
+    </nav>
+
+    <section class="shows-list" aria-label="Show dates">
+      <h2 id="upcoming">Upcoming Shows</h2>
+      <ul id="upcoming-shows"></ul>
+
+      <h2 id="past">Past Shows</h2>
+      <div id="past-shows"></div>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; 2024 Cryptic Divination. All rights reserved. | Follow us on <a href="https://www.instagram.com/crypticdivination/" target="_blank" rel="noopener noreferrer">Instagram</a> and <a href="https://www.youtube.com/@crypticdivination1886" target="_blank" rel="noopener noreferrer">YouTube</a>.</p>
+  </footer>
+
   <script id="show-data" type="application/json">
   [
     {
@@ -152,35 +183,6 @@
     }
   ]
   </script>
-</head>
-<body class="shows-page">
-  <div class="shows-background" aria-hidden="true"></div>
-
-  <main class="v2-page">
-    <section class="logo-section" aria-label="Band logo">
-      <div class="logo-crop">
-        <img src="assets/Cryptic%20Divination%20N%20L%20W.png" alt="Cryptic Divination N L W logo" class="logo-image">
-      </div>
-    </section>
-
-    <nav class="links" aria-label="Shows navigation">
-      <a href="index.html">Home</a>
-      <a href="#upcoming">Upcoming</a>
-      <a href="#past">Past</a>
-    </nav>
-
-    <section class="shows-list" aria-label="Show dates">
-      <h2 id="upcoming">Upcoming Shows</h2>
-      <ul id="upcoming-shows"></ul>
-
-      <h2 id="past">Past Shows</h2>
-      <div id="past-shows"></div>
-    </section>
-  </main>
-
-  <footer>
-    <p>&copy; 2024 Cryptic Divination. All rights reserved. | Follow us on <a href="https://www.instagram.com/crypticdivination/" target="_blank" rel="noopener noreferrer">Instagram</a> and <a href="https://www.youtube.com/@crypticdivination1886" target="_blank" rel="noopener noreferrer">YouTube</a>.</p>
-  </footer>
 
   <script>
     const shows = JSON.parse(document.getElementById('show-data').textContent);

--- a/shows.html
+++ b/shows.html
@@ -31,11 +31,6 @@
       <h2 id="past">Past Shows</h2>
       <div id="past-shows"></div>
     </section>
-  </main>
-
-  <footer>
-    <p>&copy; 2024 Cryptic Divination. All rights reserved. | Follow us on <a href="https://www.instagram.com/crypticdivination/" target="_blank" rel="noopener noreferrer">Instagram</a> and <a href="https://www.youtube.com/@crypticdivination1886" target="_blank" rel="noopener noreferrer">YouTube</a>.</p>
-  </footer>
 
   <script id="show-data" type="application/json">
   [
@@ -183,6 +178,13 @@
     }
   ]
   </script>
+  </main>
+
+  <footer>
+    <p>&copy; 2024 Cryptic Divination. All rights reserved. | Follow us on <a href="https://www.instagram.com/crypticdivination/" target="_blank" rel="noopener noreferrer">Instagram</a> and <a href="https://www.youtube.com/@crypticdivination1886" target="_blank" rel="noopener noreferrer">YouTube</a>.</p>
+  </footer>
+
+
 
   <script>
     const shows = JSON.parse(document.getElementById('show-data').textContent);


### PR DESCRIPTION
### Motivation
- Client-side SPA navigation replaces the page `main` but left the `show-data` JSON in the `<head>`, which could be absent from the live document during SPA/back/forward loads and caused intermittent shows rendering failures and full-reload fallbacks that reset the shared audio player.

### Description
- Move the `<script id="show-data" type="application/json">` block from the page `<head>` into the `<body>` so the data payload is replaced together with the page content in `shows.html` during SPA navigation.
- Preserve the existing shows renderer logic which continues to read `document.getElementById('show-data').textContent` and render the lists and year groups unchanged.
- This change is localized to `shows.html` and does not modify `assets/app-shell.js` or other pages.

### Testing
- Ran `tidy -qe shows.html` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a50735840832e9326d59e24a25fff)