### PR TITLE
Add June 21 Axe and Fiddle show

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -94,6 +94,12 @@
       "bands": ["Cryptic Divination", "Gamma Knife", "Gürschach", "Nox Sinister"]
     },
     {
+      "date": "2026/06/21",
+      "venue": "Axe and Fiddle",
+      "location": "Cottage Grove, OR",
+      "bands": ["Cryptic Divination", "Piss Mist", "Callow Ruse"]
+    },
+    {
       "date": "2025/06/21",
       "venue": "John Henry's",
       "location": "Eugene, OR",


### PR DESCRIPTION
### Motivation
- Add a new show listing for June 21, 2026 at Axe and Fiddle in Cottage Grove to keep the show's calendar current.

### Description
- Inserted a JSON show object into `shows.html` inside the `show-data` script with `date: "2026/06/21"`, `venue: "Axe and Fiddle"`, `location: "Cottage Grove, OR"`, and `bands: ["Cryptic Divination", "Piss Mist", "Callow Ruse"]`.

### Testing
- Ran `tidy -qe shows.html` which completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0d6451d4832e9468893a19cee873)