### PR TITLE
Add three upcoming shows to shows.html

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -106,6 +106,24 @@
       "bands": ["The Unbridled", "Fire Priestess", "Cryptic Divination"]
     },
     {
+      "date": "2026/08/21",
+      "venue": "John Henry's",
+      "location": "Eugene, OR",
+      "bands": ["Cryptic Divination", "Vesseles", "TBA"]
+    },
+    {
+      "date": "2026/08/23",
+      "venue": "TBA",
+      "location": "TBA",
+      "bands": ["Cryptic Divination", "Vesseles", "TBA"]
+    },
+    {
+      "date": "2026/09/25",
+      "venue": "John Henry's",
+      "location": "Eugene, OR",
+      "bands": ["Cryptic Divination", "Ghorot", "TBA"]
+    },
+    {
       "date": "2026/07/24",
       "venue": "Silver Moon Brewing",
       "location": "Bend, OR",


### PR DESCRIPTION
### Motivation
- Update the site's event listings to include newly scheduled shows and supporting bands for summer/fall 2026.

### Description
- Added three new show entries to `shows.html` for `2026/08/21` (John Henry's, Eugene, OR), `2026/08/23` (TBA), and `2026/09/25` (John Henry's, Eugene, OR) including band lineups (`Vesseles`, `Ghorot`, and `TBA`).

### Testing
- No automated tests were added or run for this static HTML content change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10b7fc8618832ea008f910b013f00e)