### PR TITLE
Align past shows with upcoming list on desktop

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -219,6 +219,7 @@ footer a {
 #past-shows {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 0.75rem;
 }
 


### PR DESCRIPTION
### Motivation
- Fix a desktop-only horizontal offset so past show groups align on the same x-axis as the upcoming show entries.

### Description
- Add `align-items: center;` to the `#past-shows` flex container in `assets/style.css` so past show cards center horizontally and match the upcoming list alignment (change applied around L219-L223).

### Testing
- Performed the scripted update and verified the change with `git diff -- assets/style.css`, `git log -1 --pretty=full`, and inspected the modified lines with `nl -ba assets/style.css | sed -n '212,232p'`; no HTML files were modified so `tidy` was not required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f1074f34832e933f2ed7dd4b17b4)