### PR TITLE
Standardize top navigation across pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,10 +9,11 @@
 </head>
 <body class="about-page">
   <main class="about-layout">
-    <nav class="about-control-bar" aria-label="About page controls">
+    <nav class="site-nav" aria-label="Primary navigation">
       <a href="index.html">Home</a>
       <a href="shows.html">Shows</a>
-      <a href="https://instagram.com/crypticdivination" target="_blank" rel="noopener noreferrer">Instagram</a>
+      <a href="music.html">Music</a>
+      <a href="https://cryptic-divination.printify.me/" target="_blank" rel="noopener noreferrer">Merch</a>
       <a href="mailto:crypticdivination@gmail.com">Contact</a>
     </nav>
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -54,6 +54,7 @@ footer {
 
 .site-nav {
   width: min(960px, 100%);
+  margin: 0 auto;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;

--- a/assets/style.css
+++ b/assets/style.css
@@ -52,7 +52,7 @@ footer {
   filter: drop-shadow(0 0 30px rgba(255, 255, 255, 0.08));
 }
 
-.links {
+.site-nav {
   width: min(960px, 100%);
   display: flex;
   flex-wrap: wrap;
@@ -60,7 +60,7 @@ footer {
   gap: 0.75rem;
 }
 
-.links a {
+.site-nav a {
   color: var(--fg);
   text-decoration: none;
   border: 1px solid var(--line);
@@ -72,8 +72,8 @@ footer {
   transition: border-color 0.2s ease, color 0.2s ease;
 }
 
-.links a:hover,
-.links a:focus-visible {
+.site-nav a:hover,
+.site-nav a:focus-visible {
   color: var(--muted);
   border-color: #575757;
 }
@@ -154,13 +154,14 @@ footer a {
     width: min(420px, 100%);
   }
 
-  .links {
+  .site-nav {
     gap: 0.55rem;
   }
 
-  .links a {
-    width: 100%;
+  .site-nav a {
     text-align: center;
+    padding: 0.5rem 0.8rem;
+    font-size: 0.74rem;
   }
 
   .audio-player {
@@ -325,27 +326,6 @@ footer a {
   filter: drop-shadow(0 0 20px rgba(0, 0, 0, 0.85));
 }
 
-.about-control-bar {
-  width: 100%;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.6rem;
-  padding: 0.6rem;
-  background: rgba(0, 0, 0, 0.75);
-  pointer-events: auto;
-}
-
-.about-control-bar a {
-  color: var(--fg);
-  text-decoration: none;
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  background: rgba(0, 0, 0, 0.65);
-  padding: 0.45rem 0.8rem;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  font-size: clamp(0.68rem, 1.35vw, 0.85rem);
-}
 
 .about-members,
 .about-bio {
@@ -375,13 +355,6 @@ footer a {
   margin: 0;
   line-height: 1.5;
   text-align: center;
-}
-
-@media (max-width: 640px) {
-  .about-control-bar {
-    gap: 0.4rem;
-    padding: 0.45rem;
-  }
 }
 
 .music-app {

--- a/index.html
+++ b/index.html
@@ -16,13 +16,13 @@
       </div>
     </section>
 
-    <section class="links" aria-label="Primary navigation links">
+    <nav class="site-nav" aria-label="Primary navigation">
       <a href="shows.html">Shows</a>
       <a href="music.html">Music</a>
       <a href="https://cryptic-divination.printify.me/" target="_blank" rel="noopener noreferrer">Merch</a>
       <a href="about.html">About</a>
       <a href="mailto:crypticdivination@gmail.com">Contact</a>
-    </section>
+    </nav>
 
     <section class="photo-section" aria-label="Volume I photo">
       <h2 class="volume-heading">Volume I, now available everywhere</h2>

--- a/music.html
+++ b/music.html
@@ -17,10 +17,12 @@
       </div>
     </section>
 
-    <nav class="links" aria-label="Music navigation">
+    <nav class="site-nav" aria-label="Primary navigation">
       <a href="index.html">Home</a>
       <a href="shows.html">Shows</a>
+      <a href="https://cryptic-divination.printify.me/" target="_blank" rel="noopener noreferrer">Merch</a>
       <a href="about.html">About</a>
+      <a href="mailto:crypticdivination@gmail.com">Contact</a>
     </nav>
 
     <section class="music-app" aria-label="Cryptic Divination streaming interface">

--- a/shows.html
+++ b/shows.html
@@ -18,10 +18,12 @@
       </div>
     </section>
 
-    <nav class="links" aria-label="Shows navigation">
+    <nav class="site-nav" aria-label="Primary navigation">
       <a href="index.html">Home</a>
-      <a href="#upcoming">Upcoming</a>
-      <a href="#past">Past</a>
+      <a href="music.html">Music</a>
+      <a href="https://cryptic-divination.printify.me/" target="_blank" rel="noopener noreferrer">Merch</a>
+      <a href="about.html">About</a>
+      <a href="mailto:crypticdivination@gmail.com">Contact</a>
     </nav>
 
     <section class="shows-list" aria-label="Show dates">


### PR DESCRIPTION
### Motivation
- Make the top navigation consistent across Home, Shows, Music and About so the header behaves like the About page on mobile and desktop. 
- Present a more standard top bar on all pages while omitting the link for the currently displayed page to avoid a redundant/current link.

### Description
- Replaced page-specific nav blocks with a shared `<nav class="site-nav">` on `index.html`, `shows.html`, `music.html`, and `about.html` and updated each page's links so the current page is not included. 
- Consolidated and renamed the old `.links` / `.about-control-bar` styling to `.site-nav` in `assets/style.css` and removed the now-unused `.about-control-bar` rules. 
- Adjusted mobile CSS for `.site-nav` so links remain a compact horizontal/top-bar style instead of stacking full-width buttons. 
- Files changed: `index.html`, `shows.html`, `music.html`, `about.html`, and `assets/style.css`.

### Testing
- Ran `tidy -qe index.html` and it completed without errors. 
- Ran `tidy -qe about.html` and it completed without errors. 
- Ran `tidy -qe shows.html` and it completed without errors. 
- Ran `tidy -qe music.html` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f21cdfe0832ea3d80d516246ac3c)