### PR TITLE
Add 'Add to Calendar' button and ICS export for shows

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -284,6 +284,25 @@ footer a {
   color: #bfc7ff;
 }
 
+.calendar-button {
+  display: inline-block;
+  margin-top: 0.5rem;
+  border: 1px solid var(--line);
+  padding: 0.45rem 0.75rem;
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.8rem;
+  color: var(--fg);
+  background: #000;
+}
+
+.calendar-button:hover,
+.calendar-button:focus-visible {
+  color: var(--muted);
+  border-color: #575757;
+}
+
 
 .about-page {
   position: relative;

--- a/shows.html
+++ b/shows.html
@@ -300,6 +300,16 @@
         details.innerHTML += `<p>${show.info}</p>`;
       }
 
+      const calendarButton = document.createElement('a');
+      calendarButton.className = 'calendar-button';
+      calendarButton.textContent = 'Add to Calendar';
+      calendarButton.href = createCalendarEventLink(show);
+      calendarButton.download = createCalendarFileName(show);
+      calendarButton.addEventListener('click', (event) => {
+        event.stopPropagation();
+      });
+      details.appendChild(calendarButton);
+
       li.addEventListener('click', () => {
         details.style.display = details.style.display === 'block' ? 'none' : 'block';
       });
@@ -307,6 +317,53 @@
       li.appendChild(summary);
       li.appendChild(details);
       return li;
+    }
+
+    function createCalendarEventLink(show) {
+      const eventDate = new Date(show.date);
+      const eventStart = new Date(eventDate);
+      eventStart.setHours(19, 0, 0, 0);
+      const eventEnd = new Date(eventStart);
+      eventEnd.setHours(eventEnd.getHours() + 3);
+
+      const eventTitle = show.name ? show.name : `${show.bands.join(', ')} at ${show.venue}`;
+      const eventDescription = `Lineup: ${show.bands.join(', ')}${show.info ? `\nInfo: ${show.info}` : ''}`;
+      const eventLocation = `${show.venue}, ${show.location}`;
+      const uid = `${show.date.replaceAll('/', '')}-${show.venue.replace(/[^a-z0-9]/gi, '').toLowerCase()}@crypticdivination.com`;
+
+      const ics = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//Cryptic Divination//Shows//EN',
+        'BEGIN:VEVENT',
+        `UID:${uid}`,
+        `DTSTAMP:${formatIcsDate(new Date())}`,
+        `DTSTART:${formatIcsDate(eventStart)}`,
+        `DTEND:${formatIcsDate(eventEnd)}`,
+        `SUMMARY:${escapeIcsText(eventTitle)}`,
+        `LOCATION:${escapeIcsText(eventLocation)}`,
+        `DESCRIPTION:${escapeIcsText(eventDescription)}`,
+        'END:VEVENT',
+        'END:VCALENDAR'
+      ].join('\r\n');
+
+      return `data:text/calendar;charset=utf-8,${encodeURIComponent(ics)}`;
+    }
+
+    function createCalendarFileName(show) {
+      return `cryptic-divination-${show.date.replaceAll('/', '-')}.ics`;
+    }
+
+    function formatIcsDate(date) {
+      return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '');
+    }
+
+    function escapeIcsText(text) {
+      return text
+        .replace(/\\/g, '\\\\')
+        .replace(/\n/g, '\\n')
+        .replace(/,/g, '\\,')
+        .replace(/;/g, '\\;');
     }
 
     function formatDate(dateStr) {


### PR DESCRIPTION
### Motivation
- Provide visitors an easy way to add a listed show to their device calendar without manual copying of details.
- Produce a portable calendar file from the existing show data so events can be imported across platforms.

### Description
- Update `shows.html` to append an `Add to Calendar` link into each show details block and prevent that click from collapsing the card. 
- Implement `createCalendarEventLink`, `createCalendarFileName`, `formatIcsDate`, and `escapeIcsText` to generate a downloadable `.ics` data URI containing UID, DTSTAMP, DTSTART, DTEND, SUMMARY, LOCATION, and DESCRIPTION from the show record. 
- Default generated events to a 7:00 PM start time with a 3-hour duration when no per-show time is available. 
- Add `.calendar-button` styling in `assets/style.css` to match the site theme and hover/focus behavior.

### Testing
- Ran `tidy -qe shows.html` to validate the modified HTML and it completed without errors. 
- Executed an inline script syntax check with `node` by evaluating the page script (`new Function(...)`) and it returned `js ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1210e14114832ebe90e274b7c263e7)