### PR TITLE
Match calendar notes to expanded show details

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -350,7 +350,7 @@
     function createCalendarEventLink(show) {
       const eventDate = new Date(show.date);
       const eventTitle = show.name ? show.name : `${show.bands.join(', ')} at ${show.venue}`;
-      const eventDescription = `Lineup: ${show.bands.join(', ')}\nStart time: TBA${show.info ? `\nInfo: ${show.info}` : ''}`;
+      const eventDescription = createCalendarEventDescription(show);
       const eventLocation = `${show.venue}, ${show.location}`;
       const uid = `${show.date.replaceAll('/', '')}-${show.venue.replace(/[^a-z0-9]/gi, '').toLowerCase()}@crypticdivination.com`;
       const hasTimedStart = Boolean(show.doors || show.music);
@@ -376,6 +376,42 @@
       return `data:text/calendar;charset=utf-8,${encodeURIComponent(ics)}`;
     }
 
+
+
+    function createCalendarEventDescription(show) {
+      const lines = [
+        `Date: ${formatDate(show.date)}`,
+        `Venue: ${show.venue}`,
+        `Location: ${show.location}`
+      ];
+
+      if (show.doors) {
+        lines.push(`Doors: ${formatTime(show.doors)}`);
+      }
+
+      if (show.music) {
+        lines.push(`Music: ${formatTime(show.music)}`);
+      }
+
+      lines.push('Lineup:');
+      show.bands.forEach((band, index) => {
+        lines.push(`${index + 1}. ${band}`);
+      });
+
+      if (show.links) {
+        lines.push('Links:');
+        show.links.forEach((link, index) => {
+          lines.push(`${index + 1}. ${link}`);
+        });
+      }
+
+      if (show.info) {
+        lines.push('');
+        lines.push(show.info);
+      }
+
+      return lines.join('\n');
+    }
 
     function createTimedEvent(show, eventDate) {
       const eventStart = new Date(eventDate);


### PR DESCRIPTION
### Motivation
- Make calendar event notes mirror the expanded show details, removing the hardcoded "Start time: TBA" fallback so calendar descriptions contain the same structured information users see in the UI.

### Description
- Replace the inline `eventDescription` string with a call to `createCalendarEventDescription(show)` in `shows.html`.
- Add `createCalendarEventDescription(show)` which constructs a multi-line description with `Date`, `Venue`, `Location`, optional `Doors`/`Music` times, a numbered `Lineup`, optional numbered `Links`, and optional extra `info`.
- The generated description is then used as the ICS `DESCRIPTION` (and continues to be escaped via `escapeIcsText`).

### Testing
- Ran `tidy -qe shows.html` to validate the modified HTML and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12150eb704832eb5f25b5f862a7313)