### PR TITLE
Autoplay shared music player on page load

### DIFF
--- a/assets/app-shell.js
+++ b/assets/app-shell.js
@@ -44,6 +44,15 @@
     }
   }
 
+
+  function tryAutoplaySharedPlayer() {
+    const shared = getSharedPlayer();
+    if (!shared) return;
+    shared.audio.play().catch(function () {
+      // Playback may be blocked by browser autoplay policy.
+    });
+  }
+
   function wireMusicTrackButtons(root) {
     const buttons = root.querySelectorAll('[data-track-src][data-track-name]');
     buttons.forEach(function (button) {
@@ -84,6 +93,7 @@
 
     wireMusicTrackButtons(document);
     runInlineScriptsFromDocument(doc);
+    tryAutoplaySharedPlayer();
 
     if (pushState) {
       history.pushState({ path: url }, '', url);
@@ -110,4 +120,5 @@
   });
 
   wireMusicTrackButtons(document);
+  tryAutoplaySharedPlayer();
 })();


### PR DESCRIPTION
### Motivation
- Ensure the on-site shared audio player attempts playback automatically on initial page load and after in-site (SPA) navigation per the requested UX change. 
- Preserve existing behavior that respects browser autoplay policies by handling `play()` promise rejections.

### Description
- Add `tryAutoplaySharedPlayer()` in `assets/app-shell.js` which calls `getSharedPlayer()` and invokes `shared.audio.play().catch(...)` to attempt playback safely.
- Invoke `tryAutoplaySharedPlayer()` during initial script startup so playback is attempted on page load. 
- Invoke `tryAutoplaySharedPlayer()` after SPA content swaps in `loadPage()` so playback is re-attempted on internal navigation; no HTML or CSS files were modified.

### Testing
- There are no automated tests in this repository to run for this change. 
- Per repository programmatic checks, no HTML files were modified so `tidy -qe` was not required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1217213590832e9db4bd387960886d)