### PR TITLE
Update Axe & Fiddle lineup

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -107,7 +107,7 @@
       "date": "2026/06/21",
       "venue": "The Axe & Fiddle",
       "location": "Cottage Grove, OR",
-      "bands": ["Cryptic Divination", "Piss Mist", "Callow Ruse"]
+      "bands": ["Veil of Ashes", "Cryptic Divination"]
     },
     {
       "date": "2025/06/21",


### PR DESCRIPTION
### Motivation
- Change the June 21, 2026 Axe & Fiddle show to a two-band bill so it lists Veil of Ashes followed by Cryptic Divination.

### Description
- Edited `shows.html` to replace the entry for the 2026/06/21 Axe & Fiddle show from `["Cryptic Divination", "Piss Mist", "Callow Ruse"]` to `["Veil of Ashes", "Cryptic Divination"]`.

### Testing
- Ran `tidy -qe shows.html` and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c2450e660832eb85cce350a0501e8)