### PR TITLE
Remove Gamma Knife from show listing

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -99,7 +99,7 @@
       "date": "2026/06/19",
       "venue": "John Henry's",
       "location": "Eugene, OR",
-      "bands": ["Cryptic Divination", "Gamma Knife", "Gürschach", "Nox Sinister"],
+      "bands": ["Cryptic Divination", "Gürschach", "Nox Sinister"],
       "doors": "20:00",
       "music": "21:00"
     },


### PR DESCRIPTION
### Motivation
- Update the June 19, 2026 John Henry's lineup to remove Gamma Knife from the bands list.

### Description
- Removed "Gamma Knife" from the `bands` array for the show on `2026/06/19` in `shows.html`.

### Testing
- Ran `tidy -qe shows.html` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c280d9318832ea5db327342d7ae4b)