### PR TITLE
Add Together We Are Enough Festival show (2026-09-26) to shows.html

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -140,6 +140,14 @@
       "music": "21:00"
     },
     {
+      "date": "2026/09/26",
+      "venue": "Washington Jefferson Skate Park",
+      "location": "Eugene, OR",
+      "bands": ["Cryptic Divination"],
+      "name": "Together We Are Enough Festival",
+      "music": "15:00"
+    },
+    {
       "date": "2026/07/24",
       "venue": "Silver Moon Brewing",
       "location": "Bend, OR",


### PR DESCRIPTION
### Motivation
- Reflect the newly scheduled festival appearance in the public show listing by adding the 2026/09/26 entry for the band.

### Description
- Insert a new JSON-style show object into `shows.html` for `2026/09/26` at `Washington Jefferson Skate Park`, `Eugene, OR` with `bands: ["Cryptic Divination"]`, `name: "Together We Are Enough Festival"`, and `music: "15:00"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a495d7d4b8c832e8051d3e8350090c7)