### PR TITLE
Update September 25 lineup

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -135,7 +135,7 @@
       "date": "2026/09/25",
       "venue": "John Henry's",
       "location": "Eugene, OR",
-      "bands": ["Cryptic Divination", "Ghorot", "TBA"],
+      "bands": ["Redivivus", "Cryptic Divination", "Private Prisons", "Ghorot"],
       "doors": "20:00",
       "music": "21:00"
     },


### PR DESCRIPTION
### Motivation
- Update the lineup for the John Henry's show on 2026-09-25 to reflect the confirmed acts Redivivus, Cryptic Divination, Private Prisons, and Ghorot.

### Description
- Replace the `bands` array for the `2026/09/25` entry in `shows.html` with `["Redivivus", "Cryptic Divination", "Private Prisons", "Ghorot"]`.

### Testing
- Ran `tidy -qe shows.html` to validate the modified HTML and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4be89ab96c832e9370207f0668b561)