### PR TITLE
Update August 21 lineup

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -121,7 +121,7 @@
       "date": "2026/08/21",
       "venue": "John Henry's",
       "location": "Eugene, OR",
-      "bands": ["Cryptic Divination", "Vesseles", "these cursed hands"],
+      "bands": ["Cryptic Divination", "Vesseles", "These Cursed Hands"],
       "doors": "20:00",
       "music": "21:00"
     },

--- a/shows.html
+++ b/shows.html
@@ -121,7 +121,7 @@
       "date": "2026/08/21",
       "venue": "John Henry's",
       "location": "Eugene, OR",
-      "bands": ["Cryptic Divination", "Vesseles", "TBA"],
+      "bands": ["Cryptic Divination", "Vesseles", "these cursed hands"],
       "doors": "20:00",
       "music": "21:00"
     },


### PR DESCRIPTION
### Motivation
- Replace the placeholder support slot for the John Henry's show on 2026-08-21 with the confirmed act name.

### Description
- Update the `shows.html` event entry for `2026/08/21` to set `bands` to `["Cryptic Divination", "Vesseles", "these cursed hands"]`.

### Testing
- Ran `tidy -qe shows.html` which completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e82000050832ebb4ef6688e1c5f1d)