### PR TITLE
Update Aug 23 show to Rockafairy (Medford) and lineup

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -127,9 +127,9 @@
     },
     {
       "date": "2026/08/23",
-      "venue": "TBA",
-      "location": "TBA",
-      "bands": ["Cryptic Divination", "Vesseles", "TBA"]
+      "venue": "Rockafairy",
+      "location": "Medford, OR",
+      "bands": ["Achromic", "Cryptic Divination", "Vesseles", "Graveburner"]
     },
     {
       "date": "2026/09/25",


### PR DESCRIPTION
### Motivation
- Publish finalized details for the August 23, 2026 show so the site lists venue, location, and full lineup.

### Description
- Edit `shows.html` JSON for the `2026/08/23` entry to set `venue` to `Rockafairy` and `location` to `Medford, OR`.
- Replace the placeholder lineup with `"bands": ["Achromic", "Cryptic Divination", "Vesseles", "Graveburner"]` for that date.
- No other pages were modified.

### Testing
- Ran `tidy -qe shows.html` on the modified file and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e8294ef70832ea0c76a9b9b4e88d6)