### PR TITLE
Remove August 23, 2026 Rockafairy show

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -126,12 +126,6 @@
       "music": "21:00"
     },
     {
-      "date": "2026/08/23",
-      "venue": "Rockafairy",
-      "location": "Medford, OR",
-      "bands": ["Achromic", "Cryptic Divination", "Vesseles", "Graveburner"]
-    },
-    {
       "date": "2026/09/25",
       "venue": "John Henry's",
       "location": "Eugene, OR",


### PR DESCRIPTION
### Motivation
- Remove the August 23, 2026 Rockafairy entry from the show schedule so the site reflects the updated lineup.

### Description
- Deleted the `2026/08/23` show object (Rockafairy — Medford, OR) from the embedded `show-data` JSON in `shows.html`.

### Testing
- Ran `tidy -qe shows.html` to validate the modified HTML and it passed.
- Ran a `python3` validation that parsed the embedded JSON and asserted no show with date `2026/08/23` exists, which succeeded.
- Ran `git diff --check` to verify no whitespace or diff issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fd946190c832eaaaa7f3acb943f63)