### PR TITLE
Reschedule September festival show

### DIFF
--- a/shows.html
+++ b/shows.html
@@ -134,12 +134,12 @@
       "music": "21:00"
     },
     {
-      "date": "2026/09/26",
+      "date": "2026/09/27",
       "venue": "Washington Jefferson Skate Park",
       "location": "Eugene, OR",
       "bands": ["Cryptic Divination"],
       "name": "Together We Are Enough Festival",
-      "music": "15:00"
+      "music": "18:30"
     },
     {
       "date": "2026/07/24",


### PR DESCRIPTION
### Motivation
- Move the "Together We Are Enough Festival" performance from September 26 to September 27 and update the performance time to 6:30 PM to reflect the new schedule.

### Description
- Updated `shows.html` by changing the festival entry's `"date"` from `2026/09/26` to `2026/09/27` and `"music"` from `15:00` to `18:30`.

### Testing
- Ran `tidy -qe shows.html`, parsed the embedded JSON to assert the festival entry has `date: 2026/09/27` and `music: 18:30`, and executed `git diff --check`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a4150f664832ebb52c1fa7a99498c)